### PR TITLE
Change autoReferenced from false to true at WebP.asmdef

### DIFF
--- a/unity_project/Assets/unity.webp/Runtime/WebP.asmdef
+++ b/unity_project/Assets/unity.webp/Runtime/WebP.asmdef
@@ -9,7 +9,7 @@
     "precompiledReferences": [
         "System.Runtime.CompilerServices.Unsafe.dll"
     ],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
Thanks for the great features, but there's one problem.

why disable autoReferenced ?
usualy enable autoReferenced at runtime module,
because many projects doesn't apply asmdef to application features.

on the other hand, 
it is possible to incorporate functions into AssemblyCSharp by creating a reference asmdef and writing a wrapper, 
but this increases the introduction cost.

So, I think it's better to set autoReferenced to true.