### PR TITLE
Fix: explicitly set list of supported platforms

### DIFF
--- a/unity_project/Assets/unity.webp/Runtime/WebP.asmdef
+++ b/unity_project/Assets/unity.webp/Runtime/WebP.asmdef
@@ -2,7 +2,17 @@
     "name": "unity.webp",
     "rootNamespace": "",
     "references": [],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Android",
+        "Editor",
+        "iOS",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WSA",
+        "WebGL",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": true,


### PR DESCRIPTION
Currently, the list of platforms in the AsmDef is very broad and thus the existance of the WebP package in projects on specific platforms breaks building.

This PR fixes that by explicitly setting which platforms are supported:
![image](https://user-images.githubusercontent.com/2693840/192551813-4fddb306-c92d-4d14-ae35-6fe1772e3dad.png)

Thus, all these platforms now at least compile when building (doesn't change that they're not supported, but no error anymore):
![image](https://user-images.githubusercontent.com/2693840/192551903-d59d76c8-1d2b-4c91-b368-c648a69cded4.png)

Before this PR:
![image](https://user-images.githubusercontent.com/2693840/192552290-360e7448-213b-42eb-8a76-8dfc0430f34f.png)
