### PR TITLE
Fix: properly add `system.runtime.compilerservices.unsafe` dependency, add easy installer link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,38 @@
 
 ## installation
 
-choose your preference
+Choose your preference:
 
-### using UPM
+### Using OpenUPM installer
 
-using `#{version}` for versioning.
+Download and install via the [Package Installer](http://package-installer.glitch.me/v1/installer/OpenUPM/com.netpyoung.webp?registry=https://package.openupm.com). No manual registry setup is needed. 
 
-ex)
+### Using OpenUPM manually
 
 ``` json
 {
   "dependencies": {
-    "com.netpyoung.webp": "https://github.com/netpyoung/unity.webp.git?path=unity_project/Assets/unity.webp#0.3.10",
-    "org.nuget.system.runtime.compilerservices.unsafe": "6.0.0"
+    "com.netpyoung.webp": "0.3.10"
+  },
+  "scopedRegistries": [
+    {
+      "name": "OpenUPM",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "com.netpyoung.webp",
+        "org.nuget.system.runtime.compilerservices.unsafe"
+      ]
+    }
+  ]
+}
+```
+
+### Using UPM from GitHub and Unity NuGet
+
+``` json
+{
+  "dependencies": {
+    "com.netpyoung.webp": "https://github.com/netpyoung/unity.webp.git?path=unity_project/Assets/unity.webp#0.3.10"
   },
   "scopedRegistries": [
     {

--- a/unity_project/Assets/unity.webp/package.json
+++ b/unity_project/Assets/unity.webp/package.json
@@ -5,6 +5,9 @@
   "unity": "2018.4",
   "description": "webp made easy for Unity3d.",
   "keywords": ["webp","unity.webp"],
+  "dependencies": {
+    "org.nuget.system.runtime.compilerservices.unsafe": "6.0.0"
+  },
   "license": "MIT",
   "category": "image"
 }


### PR DESCRIPTION
Currently, installing WebP into a project is a bit complicated because the package dependency isn't correctly specified.

For example, the OpenUPM registry will show wrong installation instructions because it can't know better.

This PR adds the dependency properly to package.json.
Also, I added alternative installation instructions that use the package installer and get both WebP and Unsafe package from OpenUPM in one step.